### PR TITLE
Fixed running in a production environment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,10 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-Dotenv::Railtie.load
+# Load environment variables for development and testing only
+if Rails.env.development? or Rails.env.test?
+  Dotenv::Railtie.load
+end
 
 module SofDbapp
   class Application < Rails::Application


### PR DESCRIPTION
Heroku failed to build the application after the Dotenv dependency was added. This PR fixes the fault by only loading it for development and test builds.

Note: Do not merge if review app fails to deploy.