### PR TITLE
Added LetsEncrypt challenge endpoint

### DIFF
--- a/app/controllers/lets_encrypt_controller.rb
+++ b/app/controllers/lets_encrypt_controller.rb
@@ -1,0 +1,19 @@
+class LetsEncryptController < ApplicationController
+  def challenge
+    if params[:id] == key
+      render plain: challenge_hash
+    else
+      render nothing: true, status: 404
+    end
+  end
+
+  def key
+    unless challenge_hash.nil?
+      challenge_hash.split('.')[0]
+    end
+  end
+
+  def challenge_hash
+    ENV['LETSENCRYPT_CHALLENGE']
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # Let’s encrypt
+  get '/.well-known/acme-challenge/:id' => 'lets_encrypt#challenge', as: :letsencrypt_challenge
 end

--- a/test/controllers/lets_encrypt_controller_test.rb
+++ b/test/controllers/lets_encrypt_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LetsEncryptControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Added a configurable endpoint for LetsEncrypt at /.well-known/acme-challenge/:id. This allows retrieval of SSL certificates for the app.

See https://github.com/studentorkesterfestivalen/sof-webapp/pull/12. This pull request also requires that all connections to the app are made over SSL.