### PR TITLE
Added the ability to disable SSL enforcement while updating certs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = !ENV['DANGEROUSLY_DONT_FORCE_SSL'].present?
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Heroku does not support SSL without any certificates installed, therefore the possibility to (dangerously) disable SSL enforcement on demand should exist.