### PR TITLE
Quick-fix for LiU-ID case issue

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,6 @@
+# Load LiU-ID fix
+require 'ext/cas'
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :cas,
            host:      'login.liu.se',

--- a/lib/ext/cas.rb
+++ b/lib/ext/cas.rb
@@ -1,0 +1,33 @@
+# Fix for https://github.com/studentorkesterfestivalen/sof-webapp/issues/53
+
+module OmniAuth
+  module Strategies
+    class CAS
+
+      private
+
+      # Overridden to correctly filter LiU-IDs.
+      # NOTE: Overriding private methods is not recommended.
+      # TODO: Find a safer solution to this problem.
+      def prune!(hash)
+        hash.delete_if do |key, value|
+          if is_liu_id? key, value
+            fix_liu_id! value
+          end
+
+          prune!(value) if value.is_a?(Hash)
+          value.nil? || (value.respond_to?(:empty?) && value.empty?)
+        end
+      end
+
+      def fix_liu_id!(value)
+        value.strip!
+        value.downcase!
+      end
+
+      def is_liu_id?(key, value)
+        key == 'user' and value.is_a?(String)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Temporarily fixes LiU-ID signup so that different case in the username will not result in different users. This relies on overriding a private method and is not very reliable but I was unable to find a better approach. Please create an issue here on GitHub for this problem if this pull request is merged!