### PR TITLE
Fix dormitory inheritance

### DIFF
--- a/app/models/orchestra_signup.rb
+++ b/app/models/orchestra_signup.rb
@@ -18,7 +18,12 @@ class OrchestraSignup < ApplicationRecord
 
   def dormitory
     # Allow dormitory to inherit from orchestra default preference
-    super || orchestra.dormitory
+    value = super
+    if value.nil?
+      orchestra.dormitory
+    else
+      value
+    end
   end
 
   def total_cost

--- a/test/fixtures/orchestra_signups.yml
+++ b/test/fixtures/orchestra_signups.yml
@@ -15,3 +15,9 @@ different_owner:
   id: 3
   user_id: 2
   orchestra: default
+
+without_dormitory:
+  id: 4
+  dormitory: false
+  orchestra: default
+  user_id: 1

--- a/test/integration/orchestra_signup_integration_test.rb
+++ b/test/integration/orchestra_signup_integration_test.rb
@@ -85,6 +85,15 @@ class OrchestraSignupIntegrationTest < AuthenticatedIntegrationTest
     assert_equal signup['dormitory'], true
   end
 
+  test 'dont inherit dormitory for negative preference' do
+    get '/api/v1/orchestra_signup/4', headers: auth_headers
+    assert_response :success
+
+    signup = JSON.parse response.body
+
+    assert_equal signup['dormitory'], false
+  end
+
   test 'orchestra owner can view member signups' do
     get '/api/v1/orchestra_signup/3', headers: auth_headers
     assert_response :success


### PR DESCRIPTION
Only return orchestra dormitory if signup dormitory is nil, not nullable. Fixes issue #15.