### PR TITLE
Return orchestra name and dormitory preference for code verification endpoint

### DIFF
--- a/app/controllers/api/v1/orchestra_signup_controller.rb
+++ b/app/controllers/api/v1/orchestra_signup_controller.rb
@@ -60,7 +60,7 @@ class API::V1::OrchestraSignupController < ApplicationController
       raise 'Unable to find matching orchestra'
     end
 
-    head :no_content
+    render :json => orchestra, only: [:name, :dormitory]
   end
 
   private

--- a/test/integration/orchestra_signup_integration_test.rb
+++ b/test/integration/orchestra_signup_integration_test.rb
@@ -122,6 +122,16 @@ class OrchestraSignupIntegrationTest < AuthenticatedIntegrationTest
     }
   end
 
+  test 'verifying code returns orchestra name and dormitory preference' do
+    get '/api/v1/orchestra_signup/verify', headers: auth_headers, params: {code: 'cafebabe'}
+    assert_response :success
+
+    orchestra = JSON.parse response.body
+
+    assert_equal 'Test orchestra', orchestra['name']
+    assert_equal true, orchestra['dormitory']
+  end
+
   private
 
   def prepare_orchestra_creation!


### PR DESCRIPTION
Makes it possible to correct issue [sof-webapp#51](https://github.com/studentorkesterfestivalen/sof-webapp/issues/51) by providing orchestra name and dormitory preference when verifying the signup code.