### PR TITLE
Prepare for integration testing by allowing local mailserver

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,16 +33,9 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: 'localhost', port: ENV['PORT'] }
 
-  # Mailtrap
+  # Mailcatcher
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-      :user_name => ENV['MAILTRAP_USER'],
-      :password => ENV['MAILTRAP_PASS'],
-      :address => 'smtp.mailtrap.io',
-      :domain => 'smtp.mailtrap.io',
-      :port => '2525',
-      :authentication => :cram_md5
-  }
+  config.action_mailer.smtp_settings = { :address => '127.0.0.1', :port => 1025 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
+  config.action_mailer.default_url_options = { host: 'localhost', port: ENV['PORT'] }
 
   # Mailtrap
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,8 +34,10 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: ENV['PORT'] }
 
   # Mailcatcher
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { :address => '127.0.0.1', :port => 1025 }
+  if ENV['LOCAL_MAILSERVER'] == 'true'
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = { :address => '127.0.0.1', :port => 1025 }
+  end
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,17 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
 
+  # Mailtrap
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+      :user_name => ENV['MAILTRAP_USER'],
+      :password => ENV['MAILTRAP_PASS'],
+      :address => 'smtp.mailtrap.io',
+      :domain => 'smtp.mailtrap.io',
+      :port => '2525',
+      :authentication => :cram_md5
+  }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
Setting the environment variable `LOCAL_MAILSERVER` to `true` enables a connection to a local mailserver running on port 1025.