### PR TITLE
Hotfix Orchestra Item Export

### DIFF
--- a/app/export/formats/orchestras_item_summary_format.rb
+++ b/app/export/formats/orchestras_item_summary_format.rb
@@ -144,7 +144,9 @@ module Formats
           when :medal, :tag
             value += item_article(signup, column)
           when :orchestra_food_ticket, :orchestra_ticket
-            increase_hash_total(value, ticket_count_increase_for(signup.send(column).kind))
+            if signup.send(column).present?
+              increase_hash_total(value, ticket_count_increase_for(signup.send(column).kind))
+            end
           when :dormitory
             if signup.send(column)
               increase_hash_total(value, ticket_count_increase_for(signup.send(:orchestra_ticket).kind))


### PR DESCRIPTION
Fails because a user has 'nil' orchestra_ticket, now only handles those that has a ticket/food_ticket present. I think this problem occured because I (lukli841) removed two tickets on RISK-SMASKs behest